### PR TITLE
Fix async download of files

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -97,7 +97,7 @@ exports.sourceNodes = async (
   const options = { ...defaultOptions, ...pluginOptions }
   const dbx = new Dropbox({ fetch, accessToken: options.accessToken })
   const files = await getFiles(dbx, options)
-  Promise.all(
+  return Promise.all(
     files.map(async file => {
       const node = await processRemoteFile({
         datum: {


### PR DESCRIPTION
Since version 0.1.0 of the plugin, files are downloaded asynchronously. Thus, nodes are not ready when pages are built and the following error is displayed: _Unknown field 'allDropboxNode' on type 'Query'._

In development mode, cached files may help but behaviour is unpredictable.

Waiting for this promise to be resolved seems to solve the issue on my side.