### PR TITLE
Implemented linking between files and folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ plugins: [
       extensions: ['.pdf', '.jpg', '.png', '.md'],
       path: '/path/to/folder',
       recursive: false,
+      createFolderNodes: false,
     },
   },
 ]
@@ -31,8 +32,10 @@ plugins: [
 * **extensions:** list of extensions used to filter out results
 * **path:** the folder to use to retrieve data. Defaults to '' which is the root of the dropbox project.
 * **recursive:** use this to retrieve files from subdirectories as well
+* **createFolderNodes** use this if you want see your nodes structured by the folders they where in
 
 ## How to query
+### With `createFolderNodes: false`
 
 The plugin provides some basic information of the remote files such as:
 
@@ -63,3 +66,60 @@ query {
   }
 }
 ```
+
+### With `createFolderNodes: true`
+
+By setting this to true, you will get the following types in graphql:
+
+```graphql
+allDropboxFolder
+allDropboxImage
+allDropboxMarkdown
+allDropboxNode // everything that's not one of the above, will be of this type
+```
+
+You can now easily query for files within a folder. Lets say you have a simple portfolio structured like this on your dropbox:
+
+```markdown
+.
++-- Project-01-Lorem-Name
+|   +-- Description.md
+|   +-- Gallery-Image-01.jpg
+|   +-- Gallery-Image-02.jpg
++-- Project-02-Ipsum-Name
+|   +--Description.md
+|   +--Gallery-Image-01.jpg
+|   +--Gallery-Image-02.jpg
+```
+
+You can now query like following in `gatsby-node.js` and create project pages with a corresponding template:
+
+```graphql
+query MyQuery {
+  allDropboxFolder(filter: {name: {regex: "/Project/"}}) {
+    group(field: name) {
+      nodes {
+        name
+        dropboxImage {
+          localFile {
+            childImageSharp {
+              fluid {
+                src
+              }
+            }
+          }
+        }
+        dropboxMarkdown {
+          localFile {
+            childMarkdownRemark {
+              html
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "gatsby-source-dropbox",
   "description": "Gatsby source plugin for creating nodes from dropbox API",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "author": "Orestis Ioannou <oorestisime@gmail.com>",
+  "contributors": [
+    "Niklas May <hello@niklasmay.com>"
+  ],
   "main": "index.js",
   "bugs": {
     "url": "https://github.com/oorestisime/gatsby-source-dropbox/issues"

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,7 +8,7 @@ const defaultOptions = {
   path: ``,
   recursive: true,
   extensions: [`.jpg`, `.png`, `.md`],
-  createFolderNodes: true,
+  createFolderNodes: false,
 }
 
 const TYPE_MARKDOWN = `dropboxMarkdown`

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -60,8 +60,6 @@ async function processRemoteFile(
 ) {
 
   let fileNodeID
-
-  console.log("fuck: ", datum)
   if (datum.internal.type === TYPE_IMAGE || datum.internal.type === TYPE_MARKDOWN || datum.internal.type === TYPE_DEFAULT) {
     const remoteDataCacheKey = `dropbox-file-${datum.id}`
     const cacheRemoteData = await cache.get(remoteDataCacheKey)
@@ -138,6 +136,10 @@ function getParentFolderName(file) {
   return parentFolderName === "" ? `root` : parentFolderName
 }
 
+/**
+ * Main functions to linking nodes
+ */
+
 function getLinkedNodes(folderNodes, fileNodes) {
   const linkedNodes = folderNodes.map(folderDatum => {
     const { name } = folderDatum
@@ -163,7 +165,7 @@ function getLinkedNodes(folderNodes, fileNodes) {
 }
 
 /**
- * Main functions to create and link nodes
+ * Main functions to creating nodes
  */
 
 function createNodeData(data, options) {
@@ -209,6 +211,7 @@ function createNodeData(data, options) {
       }
     })
   
+    // We need an extra folder for the home directory of the dropbox app
     folderNodes.push({
       id: `dropboxRoot`,
       parent: `__SOURCE__`,
@@ -232,7 +235,6 @@ exports.sourceNodes = async (
   const options = { ...defaultOptions, ...pluginOptions }
   const dbx = new Dropbox({ fetch, accessToken: options.accessToken })
   const data = await getData(dbx, options)
-
   const nodeData = createNodeData(data, options)
 
   return Promise.all(

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,8 +8,13 @@ const defaultOptions = {
   path: ``,
   recursive: true,
   extensions: [`.jpg`, `.png`, `.md`],
+  createFolderNodes: true,
 }
 
+const TYPE_MARKDOWN = `dropboxMarkdown`
+const TYPE_IMAGE = `dropboxImage`
+const TYPE_FOLDER = `dropboxFolder`
+const TYPE_DEFAULT = `dropboxNode`
 
 /**
  * Dropbox API calls
@@ -31,7 +36,7 @@ async function getTemporaryUrl(dbx, path) {
  * Get the folder id from a path and then retrive and filter files
  */
 
-async function getFiles(dbx, options) {
+async function getData(dbx, options) {
   let folderId = ``
   try {
     if (options.path !== ``) {
@@ -39,7 +44,7 @@ async function getFiles(dbx, options) {
       folderId = folder.id
     }
     const files = await listFiles(dbx, folderId, options.recursive)
-    return files.entries.filter(entry => entry[`.tag`] === `file` && options.extensions.includes(path.extname(entry.name)))
+    return files
   } catch (e) {
     console.warn(e.error)
     return []
@@ -53,8 +58,11 @@ async function getFiles(dbx, options) {
 async function processRemoteFile(
   { dbx, datum, cache, store, createNode, touchNode, createNodeId }
 ) {
+
   let fileNodeID
-  if (datum.internal.type === `DropboxNode`) {
+
+  console.log("fuck: ", datum)
+  if (datum.internal.type === TYPE_IMAGE || datum.internal.type === TYPE_MARKDOWN || datum.internal.type === TYPE_DEFAULT) {
     const remoteDataCacheKey = `dropbox-file-${datum.id}`
     const cacheRemoteData = await cache.get(remoteDataCacheKey)
 
@@ -90,28 +98,147 @@ async function processRemoteFile(
   return datum
 }
 
+/**
+ * Helper functions to create and link nodes
+ */
+
+function extractFiles(data, options){
+  return data.entries.filter(entry => entry[`.tag`] === `file` && options.extensions.includes(path.extname(entry.name)))
+}
+
+function extractFolders(data){
+ return data.entries.filter(entry => entry[`.tag`] === `folder`)
+}
+
+function getNodeType(file, options) {
+  let nodeType = TYPE_DEFAULT
+
+  if(options.createFolderNodes) {
+    const extension = path.extname(file.path_display)
+
+    switch(extension) {
+      case `.md`:
+        nodeType = TYPE_MARKDOWN
+        break
+      case `.png` || `.jpg`:
+        nodeType = TYPE_IMAGE
+        break
+      default:
+        nodeType = TYPE_DEFAULT
+        break
+    }
+  }
+
+  return nodeType
+}
+
+function getParentFolderName(file) {
+  const { path } = file
+  const parentFolderName = path.substring(0, path.lastIndexOf(`/`)).replace(`/`,``)
+  return parentFolderName === "" ? `root` : parentFolderName
+}
+
+function getLinkedNodes(folderNodes, fileNodes) {
+  const linkedNodes = folderNodes.map(folderDatum => {
+    const { name } = folderDatum
+    
+    const relatedNodes = fileNodes.filter(file => getParentFolderName(file) === name)
+
+    const relatedImageNodes = relatedNodes.filter(node => node.internal.type === TYPE_IMAGE)
+    const relatedMarkdownNodes = relatedNodes.filter(node => node.internal.type === TYPE_MARKDOWN)
+    
+    const relatedImageNodeIds = relatedImageNodes.map(node => node.id)
+    const relatedMarkdownIds = relatedMarkdownNodes.map(node => node.id)
+
+    return {
+      ...folderDatum,
+      dropboxImage___NODE: relatedImageNodeIds,
+      dropboxMarkdown___NODE: relatedMarkdownIds,
+    }
+  })
+
+  linkedNodes.push(...fileNodes)
+
+  return linkedNodes
+}
+
+/**
+ * Main functions to create and link nodes
+ */
+
+function createNodeData(data, options) {
+  const files = extractFiles(data, options)
+
+  const fileNodes = files.map(file => {
+    const data = {
+      name: file.name,
+      path: file.path_display,
+      lastModified: file.client_modified,
+    }
+
+    return {
+      id: file.id,
+      parent: `__SOURCE__`,
+      children: [],
+      internal: {
+        type: getNodeType(file, options),
+        contentDigest: JSON.stringify(data),
+      },
+      ...data,
+    }
+  })
+
+  if(options.createFolderNodes) {
+    const folders = extractFolders(data)
+  
+    const folderNodes = folders.map(folder => {
+      const data = {
+        name: folder.name,
+        path: folder.path_display,
+      }
+
+      return{
+        id: folder.id,
+        parent: `__SOURCE__`,
+        children: [],
+        internal: {
+          type: TYPE_FOLDER,
+          contentDigest: JSON.stringify(data),
+        },
+        ...data,
+      }
+    })
+  
+    folderNodes.push({
+      id: `dropboxRoot`,
+      parent: `__SOURCE__`,
+      children: [],
+      internal: {
+        type: TYPE_FOLDER,
+        contentDigest: JSON.stringify({ name: `root` }),
+      },
+    })
+
+    return getLinkedNodes(folderNodes, fileNodes)
+  } else {
+    return fileNodes
+  }
+}
+
 exports.sourceNodes = async (
   { actions: { createNode, touchNode }, store, cache, createNodeId },
   pluginOptions,
   ) => {
   const options = { ...defaultOptions, ...pluginOptions }
   const dbx = new Dropbox({ fetch, accessToken: options.accessToken })
-  const files = await getFiles(dbx, options)
+  const data = await getData(dbx, options)
+
+  const nodeData = createNodeData(data, options)
+
   return Promise.all(
-    files.map(async file => {
+    nodeData.map(async nodeDatum => {
       const node = await processRemoteFile({
-        datum: {
-          id: file.id,
-          parent: `__SOURCE__`,
-          children: [],
-          internal: {
-            type: `DropboxNode`,
-            contentDigest: file.content_hash,
-          },
-          name: file.name,
-          path: file.path_display,
-          lastModified: file.client_modified,
-        },
+        datum: nodeDatum ,
         dbx,
         createNode,
         touchNode,


### PR DESCRIPTION
Hi @oorestisime ,

I implemented linking as an non breaking change.
Despite minor changes in your code, everything works as before, if keep the options like this:

```JavaScript
const defaultOptions = {
  path: ``,
  recursive: true,
  extensions: [`.jpg`, `.png`, `.md`],
  createFolderNodes: false,
}
```

If you set `createFolderNodes` to `true`, you will get the following types in graphql (if you actually have images and markdown on your dropbox):

```graphql
allDropboxFolder
allDropboxImage
allDropboxMarkdown
DropboxFolder
DropboxImage
DropboxMarkdown
```

With this you can easily query for files within a folder.
Lets say you have a simple portfolio structured like this on your dropbox:

```markdown
.
+-- Project-01-Lorem-Name
|   +-- Description.md
|   +-- Gallery-Image-01.jpg
|   +-- Gallery-Image-02.jpg
+-- Project-02-Ipsum-Name
|   +--Description.md
|   +--Gallery-Image-01.jpg
|   +--Gallery-Image-02.jpg
```
You can now query like following in `gatsby-node.js` and create project pages with a corresponding template:

```graphql
query MyQuery {
  allDropboxFolder(filter: {name: {regex: "/Project/"}}) {
    group(field: name) {
      nodes {
        name
        dropboxImage {
          localFile {
            childImageSharp {
              fluid {
                src
              }
            }
          }
        }
        dropboxMarkdown {
          localFile {
            childMarkdownRemark {
              html
            }
          }
        }
      }
    }
  }
}
```

You could extend this workflow if you combine the dropbox app with a webhook triggering a build on netlify 🚀 

***Regarding the code changes***
I did not do any super hard stress testing, but it worked fine so far. I hope my code is easy to understand. But if you start reading from line 238 and follow the flow, it should be easy to follow

Would we happy to contribute my first PR in the open source world