### PR TITLE
Add parentNodeId to remote file nodes

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -83,6 +83,7 @@ async function processRemoteFile(
           createNodeId,
           ext,
           name: path.basename(datum.name, ext),
+          parentNodeId: datum.id,
         })
         if (fileNode) {
           fileNodeID = fileNode.id


### PR DESCRIPTION
Hi @oorestisime , @niklas-may -- thanks very much for this plugin and the latest features. This tiny PR just adds the parent link from the file node created with `createRemoteFileNode` to the dropbox node.

The change has been key to resolving relative markdown URLs for a WIP remark transformer plugin, but I believe that https://github.com/gatsbyjs/gatsby/pull/11795 and https://github.com/gatsbyjs/gatsby/issues/11942 indicate this link may also help avoid potential garbage collection issues.

I am quite new to Gatsby, and not sure how best to test this minor change. I have only tested locally using the link in my current project with a small remark plugin. Thanks!